### PR TITLE
fix(Dockerfile): add EXPOSE declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ ENV NODE_ENV production
 
 WORKDIR /app
 
+EXPOSE 8080 8081
+
 ENTRYPOINT ["node", "app.js"]


### PR DESCRIPTION
Dockerfile 中缺少了expose端口的声明