### PR TITLE
revert: migrate to new migu API

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ node app.js -o bilibili ytdlp
 | QQ 音乐                     | `qq`         |          | 需要准备自己的 `QQ_COOKIE`（请参阅下方〈环境变量〉处）。                       |
 | 酷狗音乐                    | `kugou`      | ✅       |                                                                                |
 | 酷我音乐                    | `kuwo`       | ✅       |                                                                                |
-| 咪咕音乐                    | `migu`       | ✅       |                                                                                |
+| 咪咕音乐                    | `migu`       | ✅       | 需要准备自己的 `MIGU_COOKIE`（请参阅下方〈环境变量〉处）。                     |
 | JOOX                        | `joox`       |          | 需要准备自己的 `JOOX_COOKIE`（请参阅下方〈环境变量〉处）。似乎有严格地区限制。 |
 | YouTube（纯 JS 解析方式）   | `youtube`    |          | 需要 Google 认定的**非中国大陆区域** IP 地址。                                 |
 | yt-download                 | `ytdownload` |          | **似乎不能使用**。                                                             |
@@ -189,6 +189,7 @@ node app.js -o bilibili ytdlp
 | LOG_LEVEL        | str  | 日志输出等级。请见〈日志等级〉部分。                                                              | `LOG_LEVEL=debug`                                                |
 | LOG_FILE         | str  | 从 Pino 端设置日志输出的文件位置。也可以用 `*sh` 的输出重导向功能 (`node app.js >> app.log`) 代替 | `LOG_FILE=app.log`                                               |
 | JOOX_COOKIE      | str  | JOOX 音源的 wmid 和 session_key cookie                                                            | `JOOX_COOKIE="wmid=<your_wmid>; session_key=<your_session_key>"` |
+| MIGU_COOKIE      | str  | 咪咕音源的 aversionid cookie                                                                      | `MIGU_COOKIE="<your_aversionid>"`                                |
 | QQ_COOKIE        | str  | QQ 音源的 uin 和 qm_keyst cookie                                                                  | `QQ_COOKIE="uin=<your_uin>; qm_keyst=<your_qm_keyst>"`           |
 | YOUTUBE_KEY      | str  | Youtube 音源的 Data API v3 Key                                                                    | `YOUTUBE_KEY="<your_data_api_key>"`                              |
 | SIGN_CERT        | path | 自定义证书文件                                                                                    | `SIGN_CERT="./server.crt"`                                       |

--- a/src/provider/migu.js
+++ b/src/provider/migu.js
@@ -3,59 +3,74 @@ const select = require('./select');
 const request = require('../request');
 const { getManagedCacheStorage } = require('../cache');
 
+const headers = {
+	origin: 'http://music.migu.cn/',
+	referer: 'http://m.music.migu.cn/v3/',
+	// cookie: 'migu_music_sid=' + (process.env.MIGU_COOKIE || null),
+	aversionid: process.env.MIGU_COOKIE || null,
+	channel: '0146921',
+};
+
 const format = (song) => {
+	const singerId = song.singerId.split(/\s*,\s*/);
+	const singerName = song.singerName.split(/\s*,\s*/);
 	return {
+		// id: song.copyrightId,
 		id: song.id,
-		name: song.name,
-		album: song.albums && song.albums[0],
-		artists: song.singers,
-		resources: song.newRateFormats.map((detail) => ({
-			formatType: detail.formatType,
-			url: encodeURI(detail.url || detail.androidUrl),
-		})),
+		name: song.title,
+		album: { id: song.albumId, name: song.albumName },
+		artists: singerId.map((id, index) => ({ id, name: singerName[index] })),
 	};
 };
 
 const search = (info) => {
 	const url =
-		'https://pd.musicapp.migu.cn/MIGUM3.0/v1.0/content/search_all.do?' +
-		'&ua=Android_migu&version=5.0.1&pageNo=1&pageSize=10&text=' +
+		'https://m.music.migu.cn/migu/remoting/scr_search_tag?' +
+		'keyword=' +
 		encodeURIComponent(info.keyword) +
-		'&searchSwitch=' +
-		'{"song":1,"album":0,"singer":0,"tagSong":0,"mvSong":0,"songlist":0,"bestShow":1}';
+		'&type=2&rows=20&pgc=1';
 
-	return request('GET', url)
+	return request('GET', url, headers)
 		.then((response) => response.json())
 		.then((jsonBody) => {
-			const list = ((jsonBody || {}).songResultData.result || []).map(
-				format
-			);
+			const list = ((jsonBody || {}).musics || []).map(format);
 			const matched = select(list, info);
-			return matched ? matched.resources : Promise.reject();
+			return matched ? matched.id : Promise.reject();
 		});
 };
 
-const single = (resources, format) => {
-	const song = resources.find(
-		(song) => song.url && song.formatType === format
-	);
+const single = (id, format) => {
+	// const url =
+	//	'https://music.migu.cn/v3/api/music/audioPlayer/getPlayInfo?' +
+	//	'dataType=2&' + crypto.miguapi.encryptBody({copyrightId: id.toString(), type: format})
 
-	if (song) {
-		const playUrl = new URL(song.url);
-		playUrl.protocol = 'http';
-		playUrl.hostname = 'freetyst.nf.migu.cn';
-		return playUrl.href;
-	} else return false;
+	const url =
+		'https://app.c.nf.migu.cn/MIGUM2.0/strategy/listen-url/v2.4?' +
+		'netType=01&resourceType=2&songId=' +
+		id.toString() +
+		'&toneFlag=' +
+		format;
+
+	return request('GET', url, headers)
+		.then((response) => response.json())
+		.then((jsonBody) => {
+			// const {playUrl} = jsonBody.data
+			// return playUrl ? encodeURI('http:' + playUrl) : Promise.reject()
+			const { audioFormatType } = jsonBody.data;
+			if (audioFormatType !== format) return Promise.reject();
+			else return url ? jsonBody.data.url : Promise.reject();
+		});
 };
 
-const track = (resources) =>
+const track = (id) =>
 	Promise.all(
-		['ZQ', 'SQ', 'HQ', 'PQ']
+		// [3, 2, 1].slice(select.ENABLE_FLAC ? 0 : 1)
+		['ZQ24', 'SQ', 'HQ', 'PQ']
 			.slice(select.ENABLE_FLAC ? 0 : 2)
-			.map((format) => single(resources, format))
+			.map((format) => single(id, format).catch(() => null))
 	)
 		.then((result) => result.find((url) => url) || Promise.reject())
-		.catch(() => insure().migu.track(resources));
+		.catch(() => insure().migu.track(id));
 
 const cs = getManagedCacheStorage('provider/migu');
 const check = (info) => cs.cache(info, () => search(info)).then(track);


### PR DESCRIPTION
目前的 migu API 似乎壞掉了——除了周杰倫、以及少數英語名稱歌曲外，其餘都變成周杰倫的隨機曲目（如本草綱目）了。

This reverts commit 71e3b85f6b80439183df9f0ff42346ed3d8692b1.

Closed #770