### PR TITLE
Fix: QQ music provider / Feature: read QQ music cookie from file

### DIFF
--- a/src/provider/qq.js
+++ b/src/provider/qq.js
@@ -10,29 +10,37 @@ const headers = {
 };
 
 const format = (song) => ({
-	id: { song: song.songmid, file: song.media_mid },
-	name: song.songname,
+	id: { song: song.mid, file: song.mid },
+	name: song.name,
 	duration: song.interval * 1000,
-	album: { id: song.albummid, name: song.albumname },
+	album: { id: song.album.mid, name: song.album.name },
 	artists: song.singer.map(({ mid, name }) => ({ id: mid, name })),
 });
 
 const search = (info) => {
 	const url =
-		'https://c.y.qq.com/soso/fcgi-bin/client_search_cp?' +
-		'ct=24&qqmusic_ver=1298&remoteplace=txt.yqq.center&' +
-		't=0&aggr=1&cr=1&catZhida=1&lossless=0&flag_qc=0&p=1&n=20&w=' +
-		encodeURIComponent(info.keyword) +
-		'&' +
-		'g_tk=5381&jsonpCallback=MusicJsonCallback10005317669353331&loginUin=0&hostUin=0&' +
-		'format=jsonp&inCharset=utf8&outCharset=utf-8&notice=0&platform=yqq&needNewCode=0';
+		'https://u.y.qq.com/cgi-bin/musicu.fcg?data=' +
+		encodeURIComponent(
+			JSON.stringify({
+				"search": {
+					method: 'DoSearchForQQMusicDesktop',
+					module: 'music.search.SearchCgiService',
+					param: {
+						num_per_page: 5,
+						page_num: 1,
+						query: info.keyword,
+						search_type: 0
+					},
+				}
+			})
+		);
 
-	return request('GET', url)
-		.then((response) => response.jsonp())
-		.then((jsonBody) => {
-			const list = jsonBody.data.song.list.map(format);
-			const matched = select(list, info);
-			return matched ? matched.id : Promise.reject();
+	return request('GET', url, headers)
+		.then((response) => response.json())
+		.then(jsonBody => {
+			const result = jsonBody.search.data.body.song.list.slice(0, 5).map(format);
+			const matched = select(result, info);
+			return matched ? matched.id : Promise.reject("qqmusic: do_search: not matched.");
 		});
 };
 


### PR DESCRIPTION
This PR fixes the QQ music provider.

The previous QQ music api seems to be unstable on some places. It periodically returns 404 error, or returns 404 error all the time. The QQ music api in this commit seems to be reliable.

Maybe fix part of #843.

This PR also add the feature of reading QQ music cookie in a file.

This commit addes a environment variable QQ_COOKIE_PATH, which indicates the path of a QQ music cookie file (in semicolon seperated text format). Users can use other softwares to automatically obtain QQ music cookie and then write to this file, so that UNM can works with QQ music without restarting.