### PR TITLE
feat(provider/find): allow album names to be added to search keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,25 +177,26 @@ node app.js -o bilibili ytdlp
 
 ### 环境变量
 
-| 变量名称              | 类型 | 描述                                                                                              | 示例                                                             |
-| --------------------- | ---- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| ENABLE_FLAC           | bool | 激活无损音质获取                                                                                  | `ENABLE_FLAC=true`                                               |
-| ENABLE_LOCAL_VIP      | bool | 激活本地黑胶 VIP                                                                                  | `ENABLE_LOCAL_VIP=true`                                          |
-| ENABLE_HTTPDNS        | bool | 激活故障的 Netease HTTPDNS 查询（不建议）                                                         | `ENABLE_HTTPDNS=true`                                            |
-| DISABLE_UPGRADE_CHECK | bool | 禁用更新检测。                                                                                    | `DISABLE_UPGRADE_CHECK=true`                                     |
-| DEVELOPMENT           | bool | 激活开发模式。需要自己用 `yarn` 安装依赖 (dependencies)                                           | `DEVELOPMENT=true`                                               |
-| FOLLOW_SOURCE_ORDER   | bool | 严格按照配置音源的顺序进行查询                                                                    | `FOLLOW_SOURCE_ORDER=true`                                       |
-| JSON_LOG              | bool | 输出机器可读的 JSON 记录格式                                                                      | `JSON_LOG=true`                                                  |
-| NO_CACHE              | bool | 停用 cache                                                                                        | `NO_CACHE=true`                                                  |
-| MIN_BR                | int  | 允许的最低源音质，小于该值将被替换                                                                | `MIN_BR=320000`                                                  |
-| LOG_LEVEL             | str  | 日志输出等级。请见〈日志等级〉部分。                                                              | `LOG_LEVEL=debug`                                                |
+| 变量名称                  | 类型   | 描述                                                                  | 示例                                                               |
+|-----------------------|------|---------------------------------------------------------------------|------------------------------------------------------------------|
+| ENABLE_FLAC           | bool | 激活无损音质获取                                                            | `ENABLE_FLAC=true`                                               |
+| ENABLE_LOCAL_VIP      | bool | 激活本地黑胶 VIP                                                          | `ENABLE_LOCAL_VIP=true`                                          |
+| ENABLE_HTTPDNS        | bool | 激活故障的 Netease HTTPDNS 查询（不建议）                                       | `ENABLE_HTTPDNS=true`                                            |
+| DISABLE_UPGRADE_CHECK | bool | 禁用更新检测。                                                             | `DISABLE_UPGRADE_CHECK=true`                                     |
+| DEVELOPMENT           | bool | 激活开发模式。需要自己用 `yarn` 安装依赖 (dependencies)                             | `DEVELOPMENT=true`                                               |
+| FOLLOW_SOURCE_ORDER   | bool | 严格按照配置音源的顺序进行查询                                                     | `FOLLOW_SOURCE_ORDER=true`                                       |
+| JSON_LOG              | bool | 输出机器可读的 JSON 记录格式                                                   | `JSON_LOG=true`                                                  |
+| NO_CACHE              | bool | 停用 cache                                                            | `NO_CACHE=true`                                                  |
+| MIN_BR                | int  | 允许的最低源音质，小于该值将被替换                                                   | `MIN_BR=320000`                                                  |
+| LOG_LEVEL             | str  | 日志输出等级。请见〈日志等级〉部分。                                                  | `LOG_LEVEL=debug`                                                |
 | LOG_FILE              | str  | 从 Pino 端设置日志输出的文件位置。也可以用 `*sh` 的输出重导向功能 (`node app.js >> app.log`) 代替 | `LOG_FILE=app.log`                                               |
-| JOOX_COOKIE           | str  | JOOX 音源的 wmid 和 session_key cookie                                                            | `JOOX_COOKIE="wmid=<your_wmid>; session_key=<your_session_key>"` |
-| MIGU_COOKIE           | str  | 咪咕音源的 aversionid cookie                                                                      | `MIGU_COOKIE="<your_aversionid>"`                                |
-| QQ_COOKIE             | str  | QQ 音源的 uin 和 qm_keyst cookie                                                                  | `QQ_COOKIE="uin=<your_uin>; qm_keyst=<your_qm_keyst>"`           |
-| YOUTUBE_KEY           | str  | Youtube 音源的 Data API v3 Key                                                                    | `YOUTUBE_KEY="<your_data_api_key>"`                              |
-| SIGN_CERT             | path | 自定义证书文件                                                                                    | `SIGN_CERT="./server.crt"`                                       |
-| SIGN_KEY              | path | 自定义密钥文件                                                                                    | `SIGN_KEY="./server.key"`                                        |
+| JOOX_COOKIE           | str  | JOOX 音源的 wmid 和 session_key cookie                                  | `JOOX_COOKIE="wmid=<your_wmid>; session_key=<your_session_key>"` |
+| MIGU_COOKIE           | str  | 咪咕音源的 aversionid cookie                                             | `MIGU_COOKIE="<your_aversionid>"`                                |
+| QQ_COOKIE             | str  | QQ 音源的 uin 和 qm_keyst cookie                                        | `QQ_COOKIE="uin=<your_uin>; qm_keyst=<your_qm_keyst>"`           |
+| YOUTUBE_KEY           | str  | Youtube 音源的 Data API v3 Key                                         | `YOUTUBE_KEY="<your_data_api_key>"`                              |
+| SIGN_CERT             | path | 自定义证书文件                                                             | `SIGN_CERT="./server.crt"`                                       |
+| SIGN_KEY              | path | 自定义密钥文件                                                             | `SIGN_KEY="./server.key"`                                        |
+| SEARCH_ALBUM          | bool | 在其他音源搜索歌曲时携带专辑名称（默认搜索条件 `歌曲名 - 歌手`，启用后搜索条件 `歌曲名 - 歌手 专辑名`）          | `SEARCH_ALBUM=true`                                              |
 
 #### 日志等级 (`LOG_LEVEL`)
 

--- a/src/provider/find.js
+++ b/src/provider/find.js
@@ -37,6 +37,12 @@ const getFormatData = (data) => {
 			info.name +
 			' - ' +
 			limit(info.artists.map((artist) => artist.name)).join(' / ');
+		if (process.env.SEARCH_ALBUM === "true") {
+			let album = info.album?.name;
+			if (album && album !== info.name) {
+				info.keyword += ` ${album}`
+			};
+		}
 		return info;
 	} catch (err) {
 		console.log('getFormatData err: ', err);


### PR DESCRIPTION
**主要变化**

添加了一个环境变量 `SEARCH_ALBUM`，当 `SEARCH_ALBUM` 设置为 `true` 时，会在其他音源的搜索关键字中添加专辑名称，搜索关键词格式从 `歌曲名 - 歌手` 变为 `歌曲名 - 歌手 专辑名`。

例外：如果专辑名和歌曲名一致，则不添加专辑名。

**改动目的** 

在歌曲有较多版本时能够更精确的匹配到歌曲。

**当前问题**

举一个 QQ 音乐的 bad case

在 QQ 音乐中，关键词 `东北民谣 (Live) - 毛不易` 默认返回的是合唱吧的版本，并且折叠了我是唱作人的歌曲版本

<img width="803" alt="image" src="https://user-images.githubusercontent.com/7138906/209323562-8426ac45-f36e-4113-9f62-edea1fd5135b.png">

在 API 的响应中也没有我是唱作人版本的歌曲信息


```json
[
      {
        "id": "75945187",
        "name": "东北民谣",
        "duration": 243000,
        "album": {
          "id": "10632126",
          "name": "合唱吧！300&nbsp;第6期"
        },
        "artists": [
          {
            "id": 1456705,
            "name": "毛不易"
          }
        ]
      },
      {
        "id": "186102653",
        "name": "东北民谣",
        "duration": 59000,
        "album": {
          "id": "0",
          "name": ""
        },
        "artists": [
          {
            "id": 1456705,
            "name": "毛不易"
          }
        ]
      },
      ...
    ]
```
展开后才能看到我是唱作人的版本

<img width="795" alt="image" src="https://user-images.githubusercontent.com/7138906/209324850-03bc034d-92b3-4539-91c9-fb16660e4901.png">

这导致在播放这首歌的我是唱作人版本时，由于没有完全一致的歌曲匹配，最终会选择错误的结果（目前是选择了小沈阳的跨界歌王版本）。

在关键词中加入专辑名称后，就能够返回更匹配的结果

<img width="795" alt="image" src="https://user-images.githubusercontent.com/7138906/209326232-8daa610b-b8fa-4522-a87d-0dce78149ab5.png">

