### PR TITLE
refactor!(webpack): Speed up minimization

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,16 +34,13 @@ module.exports = {
 		minimize: true,
 		minimizer: [
 			new TerserPlugin({
-				// parallel: false,
+				parallel: true,
+				minify: TerserPlugin.swcMinify,
 				terserOptions: {
 					compress: {
-						ecma: 2019,
+						ecma: 2018,
 					},
-					mangle: false,
-					format: {
-						semicolons: false,
-					},
-					// https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+					// https://swc.rs/docs/configuration/minification#jscminifycompress
 				},
 			}),
 		],


### PR DESCRIPTION
Since `swc-minify` does not support semicolons-less
minification, I removes the related configuration.
It may make debugging harder but produces smaller
artifacts (and make the compression 60%+ faster!)
