### PR TITLE
fix(hook): remove unnecessary conditions

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -282,7 +282,7 @@ hook.request.after = (ctx) => {
 					);
 				}
 
-				if (netease.encrypted && ENABLE_LOCAL_VIP) {
+				if (ENABLE_LOCAL_VIP) {
 					if (
 						netease.path === '/batch' ||
 						netease.path === '/api/batch'


### PR DESCRIPTION
移除 `netease.encrypted`，否则 local_vip  可能不生效