### PR TITLE
fix(generate-cert): improve compatibility with Git Bash on Windows

### DIFF
--- a/generate-cert.sh
+++ b/generate-cert.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
 
+case "$OSTYPE" in
+    msys*|cygwin*)
+        export MSYS_NO_PATHCONV=1
+        export MSYS2_ARG_CONV_EXCL="*"
+        ;;
+esac
+
 TYPE="${TYPE:-RSA}"
 ISSUENAME="${ISSUENAME:-nobody}"
+
+cat > san.cnf <<EOF
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:music.163.com,DNS:*.music.163.com
+EOF
 
 if [ "$TYPE" == "RSA" ]; then
 	openssl genrsa -out ca.key 2048
 	openssl req -x509 -new -nodes -key ca.key -sha256 -days 1825 -out ca.crt -subj "/C=CN/CN=UnblockNeteaseMusic Root CA/O=$ISSUENAME"
 	openssl genrsa -out server.key 2048
 	openssl req -new -sha256 -key server.key -out server.csr -subj "/C=CN/L=Hangzhou/O=NetEase (Hangzhou) Network Co., Ltd/OU=IT Dept./CN=*.music.163.com"
-	openssl x509 -req -extfile <(printf "extendedKeyUsage=serverAuth\nsubjectAltName=DNS:music.163.com,DNS:*.music.163.com") -sha256 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
+	openssl x509 -req -extfile san.cnf -sha256 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 elif [ "$TYPE" == "ECC" ]; then
 	openssl ecparam -genkey -name secp384r1 -out ca.key
 	openssl req -x509 -new -nodes -key ca.key -sha384 -days 1825 -out ca.crt -subj "/C=CN/CN=UnblockNeteaseMusic Root CA/O=$ISSUENAME"
 	openssl ecparam -genkey -name secp384r1 -out server.key
 	openssl req -new -sha384 -key server.key -out server.csr -subj "/C=CN/L=Hangzhou/O=NetEase (Hangzhou) Network Co., Ltd/OU=IT Dept./CN=*.music.163.com"
-	openssl x509 -req -extfile <(printf "extendedKeyUsage=serverAuth\nsubjectAltName=DNS:music.163.com,DNS:*.music.163.com") -sha384 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
+	openssl x509 -req -extfile san.cnf -sha384 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 fi

--- a/generate-cert.sh
+++ b/generate-cert.sh
@@ -28,3 +28,5 @@ elif [ "$TYPE" == "ECC" ]; then
 	openssl req -new -sha384 -key server.key -out server.csr -subj "/C=CN/L=Hangzhou/O=NetEase (Hangzhou) Network Co., Ltd/OU=IT Dept./CN=*.music.163.com"
 	openssl x509 -req -extfile san.cnf -sha384 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 fi
+
+rm -f san.cnf


### PR DESCRIPTION
### Summary

This PR improves the compatibility of `generate-cert.sh` when executed under Git Bash on Windows.

### Problem

The original script may fail under Git Bash because:

- MSYS path conversion rewrites `-subj "/C=CN/..."`.
- Process substitution (`<(printf ...)`) may not be supported by the OpenSSL build bundled with Git for Windows.

Typical errors include:
req: subject name is expected...
Can't open /proc/.../fd/...


### Changes

- Disable MSYS path conversion.
- Replace process substitution with a temporary `san.cnf` file.

These changes preserve the original behavior while allowing the script to run correctly under Git Bash on Windows.